### PR TITLE
fix desktop OS examples

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -24,7 +24,7 @@ A clear and concise description of what you expected to happen.
 If applicable, add screenshots to help explain your problem.
 
 **Desktop (please complete the following information):**
- - OS: [e.g. iOS]
+ - OS: [e.g. Windows 8, Ubuntu Linux]
  - Browser [e.g. chrome, safari]
  - Version [e.g. 22]
 


### PR DESCRIPTION
removes iOS as desktop OS and adds Windows/Linux instead