### PR TITLE
ref #92: Exclude doctrine channel by default to avoid log flooding

### DIFF
--- a/app/config/config_dev.yml
+++ b/app/config/config_dev.yml
@@ -22,7 +22,7 @@ monolog:
       type: stream
       path: "%kernel.logs_dir%/%kernel.environment%.log"
       level: debug
-      channels: ["!event"]
+      channels: ["!event", "!doctrine"]
     # uncomment to get logging in your browser
     # you may have to allow bigger header sizes in your Web server configuration
     #firephp:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed issues  | #92
| License       | MIT


